### PR TITLE
Improve IDEAM wind data parsing and add department filters

### DIFF
--- a/lib/models/wind_data.dart
+++ b/lib/models/wind_data.dart
@@ -1,4 +1,18 @@
 class WindData {
+  static const int codigoIndex = 0;
+  static const int fechaIndex = 1;
+  static const int velocidadIndex = 2;
+  static const int departamentoIndex = 3;
+  static const int municipioIndex = 4;
+  static const int estacionIndex = 5;
+  static const int latitudIndex = 6;
+  static const int longitudIndex = 7;
+  static const int direccionIndex = 8;
+  static const int temperaturaIndex = 9;
+  static const int humedadIndex = 10;
+  static const int presionIndex = 11;
+
+  final String? codigo;
   final String? estacion;
   final String? departamento;
   final String? municipio;
@@ -8,8 +22,11 @@ class WindData {
   final double? temperatura;
   final double? humedad;
   final double? presion;
+  final double? latitud;
+  final double? longitud;
 
-  WindData({
+  const WindData({
+    this.codigo,
     this.estacion,
     this.departamento,
     this.municipio,
@@ -19,29 +36,45 @@ class WindData {
     this.temperatura,
     this.humedad,
     this.presion,
+    this.latitud,
+    this.longitud,
   });
 
-  factory WindData.fromJson(Map<String, dynamic> json) {
+  factory WindData.fromRow(List<dynamic> row) {
+    String? stringAt(int index) {
+      if (index >= row.length) return null;
+      final value = row[index];
+      if (value == null) return null;
+      final text = value.toString().trim();
+      return text.isEmpty ? null : text;
+    }
+
+    double? doubleAt(int index) {
+      final value = stringAt(index);
+      if (value == null) return null;
+      final normalized = value.replaceAll(',', '.');
+      return double.tryParse(normalized);
+    }
+
+    DateTime? dateAt(int index) {
+      final value = stringAt(index);
+      if (value == null) return null;
+      return DateTime.tryParse(value);
+    }
+
     return WindData(
-      estacion: json['estacion']?.toString(),
-      departamento: json['departamento']?.toString(),
-      municipio: json['municipio']?.toString(),
-      fechaObservacion: json['fechaobservacion'] != null 
-          ? DateTime.tryParse(json['fechaobservacion'].toString())
-          : null,
-      velocidadViento: json['velocidadviento'] != null 
-          ? double.tryParse(json['velocidadviento'].toString())
-          : null,
-      direccionViento: json['direccionviento']?.toString(),
-      temperatura: json['temperatura'] != null 
-          ? double.tryParse(json['temperatura'].toString())
-          : null,
-      humedad: json['humedad'] != null 
-          ? double.tryParse(json['humedad'].toString())
-          : null,
-      presion: json['presion'] != null 
-          ? double.tryParse(json['presion'].toString())
-          : null,
+      codigo: stringAt(codigoIndex),
+      fechaObservacion: dateAt(fechaIndex),
+      velocidadViento: doubleAt(velocidadIndex),
+      departamento: stringAt(departamentoIndex),
+      municipio: stringAt(municipioIndex),
+      estacion: stringAt(estacionIndex),
+      latitud: doubleAt(latitudIndex),
+      longitud: doubleAt(longitudIndex),
+      direccionViento: stringAt(direccionIndex),
+      temperatura: doubleAt(temperaturaIndex),
+      humedad: doubleAt(humedadIndex),
+      presion: doubleAt(presionIndex),
     );
   }
 }

--- a/lib/screens/weather_screen.dart
+++ b/lib/screens/weather_screen.dart
@@ -16,6 +16,8 @@ class _WeatherScreenState extends State<WeatherScreen> {
   bool _isLoading = true;
   String? _error;
   String _searchQuery = '';
+  String? _selectedDepartment;
+  List<String> _departments = [];
 
   @override
   void initState() {
@@ -30,9 +32,15 @@ class _WeatherScreenState extends State<WeatherScreen> {
     });
 
     try {
-      final data = await _weatherService.getWindData();
+      final data = await _weatherService.getWindData(
+        department: _selectedDepartment,
+      );
+      final departments = _extractDepartments(data);
       setState(() {
         _windData = data;
+        if (_selectedDepartment == null || _departments.isEmpty) {
+          _departments = departments;
+        }
         _isLoading = false;
       });
     } catch (e) {
@@ -47,7 +55,7 @@ class _WeatherScreenState extends State<WeatherScreen> {
     if (_searchQuery.isEmpty) {
       return _windData;
     }
-    
+
     return _windData.where((data) {
       final estacion = data.estacion?.toLowerCase() ?? '';
       final municipio = data.municipio?.toLowerCase() ?? '';
@@ -58,6 +66,18 @@ class _WeatherScreenState extends State<WeatherScreen> {
              municipio.contains(query) || 
              departamento.contains(query);
     }).toList();
+  }
+
+  List<String> _extractDepartments(List<WindData> data) {
+    final set = <String>{};
+    for (final item in data) {
+      final departamento = item.departamento?.trim();
+      if (departamento != null && departamento.isNotEmpty) {
+        set.add(departamento);
+      }
+    }
+    final list = set.toList()..sort();
+    return list;
   }
 
   @override
@@ -112,10 +132,29 @@ class _WeatherScreenState extends State<WeatherScreen> {
                     fontWeight: FontWeight.bold,
                   ),
                 ),
+                if (_selectedDepartment != null) ...[
+                  const SizedBox(height: 12),
+                  Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                    decoration: BoxDecoration(
+                      color: Colors.white.withOpacity(0.15),
+                      borderRadius: BorderRadius.circular(30),
+                    ),
+                    child: Text(
+                      'Departamento: $_selectedDepartment',
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                ],
               ],
             ),
           ),
-          
+
           // Barra de búsqueda
           Padding(
             padding: const EdgeInsets.all(16),
@@ -141,7 +180,53 @@ class _WeatherScreenState extends State<WeatherScreen> {
               ),
             ),
           ),
-          
+
+          // Filtro por departamento
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: DropdownButtonFormField<String?>(
+              value: _selectedDepartment,
+              isExpanded: true,
+              decoration: InputDecoration(
+                labelText: 'Filtrar por departamento',
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: BorderSide.none,
+                ),
+                filled: true,
+                fillColor: Colors.white,
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 4,
+                ),
+              ),
+              icon: const Icon(Icons.keyboard_arrow_down_rounded),
+              items: [
+                const DropdownMenuItem<String?>(
+                  value: null,
+                  child: Text('Todos los departamentos'),
+                ),
+                ..._departments.map(
+                  (dept) => DropdownMenuItem<String?>(
+                    value: dept,
+                    child: Text(dept),
+                  ),
+                ),
+              ],
+              onChanged: (value) {
+                setState(() {
+                  _selectedDepartment = value;
+                  if (value != null && !_departments.contains(value)) {
+                    _departments = [..._departments, value]..sort();
+                  }
+                });
+                _loadWeatherData();
+              },
+            ),
+          ),
+
+          const SizedBox(height: 8),
+
           // Contenido principal
           Expanded(
             child: _buildContent(),
@@ -220,8 +305,10 @@ class _WeatherScreenState extends State<WeatherScreen> {
             ),
             const SizedBox(height: 16),
             Text(
-              _searchQuery.isEmpty 
-                  ? 'No hay datos disponibles'
+              _searchQuery.isEmpty
+                  ? (_selectedDepartment == null
+                      ? 'No hay datos disponibles'
+                      : 'No hay datos para el departamento seleccionado')
                   : 'No se encontraron resultados',
               style: TextStyle(
                 fontSize: 18,
@@ -232,6 +319,15 @@ class _WeatherScreenState extends State<WeatherScreen> {
               const SizedBox(height: 8),
               Text(
                 'Intenta con otros términos de búsqueda',
+                style: TextStyle(
+                  color: Colors.grey[500],
+                ),
+              ),
+            ] else if (_selectedDepartment != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                'Puedes seleccionar "Todos los departamentos" para ver más datos',
+                textAlign: TextAlign.center,
                 style: TextStyle(
                   color: Colors.grey[500],
                 ),

--- a/lib/services/weather_service.dart
+++ b/lib/services/weather_service.dart
@@ -3,66 +3,58 @@ import 'package:http/http.dart' as http;
 import '../models/wind_data.dart';
 
 class WeatherService {
-  static const String baseUrl = 'https://www.datos.gov.co/api/v3/views/sgfv-3yp8/query.json';
-  static const String appToken = '8xr6o5n2fu2bndgir6d0ircie';
-  static const String apiKey = '37fclj0a0x0j4p9ax9h1dcdb31nec5je836r4141m4tzndtcza';
+  static const String baseUrl =
+      'https://www.datos.gov.co/api/v3/views/sgfv-3yp8/query.json';
+  static const String appToken = 'FMY120k5usxrMjkb8hGs3LpfB';
 
-  Future<List<WindData>> getWindData() async {
+  final http.Client _client;
+
+  WeatherService({http.Client? client}) : _client = client ?? http.Client();
+
+  Future<List<WindData>> getWindData({String? department}) async {
     try {
-      final uri = Uri.parse(baseUrl).replace(queryParameters: {
-        '\$\$app_token': appToken,
-      });
-      
-      final response = await http.get(
+      final Map<String, String> queryParameters = {
+        'limit': '200',
+        r'$order': 'fecha DESC',
+      };
+
+      if (department != null && department.trim().isNotEmpty) {
+        final normalized = department.trim().toUpperCase().replaceAll("'", "''");
+        queryParameters[r'$where'] = "upper(departamento)='$normalized'";
+      }
+
+      final uri = Uri.parse(baseUrl).replace(queryParameters: queryParameters);
+
+      final response = await _client.get(
         uri,
         headers: {
           'X-App-Token': appToken,
-          'Authorization': 'Bearer $apiKey',
           'Content-Type': 'application/json',
         },
       );
-      
-      if (response.statusCode == 200) {
-        final Map<String, dynamic> jsonData = json.decode(response.body);
-        
-        // La API devuelve los datos en el campo 'data'
-        final List<dynamic> dataList = jsonData['data'] ?? [];
-        
-        // Convertir cada elemento a WindData
-        List<WindData> windDataList = dataList.map((item) {
-          // Los datos vienen como array, necesitamos mapearlos a un objeto
-          if (item is List && item.length >= 9) {
-            return WindData.fromJson({
-              'estacion': item[8],
-              'departamento': item[9],
-              'municipio': item[10],
-              'fechaobservacion': item[11],
-              'velocidadviento': item[12],
-              'direccionviento': item[13],
-              'temperatura': item[14],
-              'humedad': item[15],
-              'presion': item[16],
-            });
-          }
-          return WindData();
-        }).where((data) => data.estacion != null).toList();
-        
-        return windDataList;
-      } else if (response.statusCode == 403) {
-        throw Exception('Error de autenticación: Verifica las API keys');
-      } else if (response.statusCode == 429) {
-        throw Exception('Límite de solicitudes excedido. Intenta más tarde');
-      } else {
+
+      if (response.statusCode != 200) {
         throw Exception('Error al cargar datos: ${response.statusCode}');
       }
+
+      final Map<String, dynamic> jsonData = json.decode(response.body);
+      final List<dynamic> dataList = (jsonData['data'] as List<dynamic>?) ?? [];
+
+      final windDataList = dataList
+          .whereType<List>()
+          .map((row) => WindData.fromRow(row))
+          .toList();
+
+      return windDataList;
     } catch (e) {
-      if (e.toString().contains('SocketException')) {
+      final message = e.toString();
+      if (message.contains('SocketException')) {
         throw Exception('Sin conexión a internet');
-      } else if (e.toString().contains('TimeoutException')) {
-        throw Exception('Tiempo de espera agotado');
-      } else {
-        throw Exception('Error de conexión: $e');
       }
+      if (message.contains('TimeoutException')) {
+        throw Exception('Tiempo de espera agotado');
+      }
+      throw Exception('Error de conexión: $e');
     }
   }
 }

--- a/lib/widgets/wind_card.dart
+++ b/lib/widgets/wind_card.dart
@@ -42,7 +42,18 @@ class WindCard extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 8),
-            
+
+            if (windData.codigo != null) ...[
+              Text(
+                'Código estación: ${windData.codigo}',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Colors.grey[600],
+                ),
+              ),
+              const SizedBox(height: 8),
+            ],
+
             // Ubicación
             Text(
               '${windData.municipio ?? 'N/A'}, ${windData.departamento ?? 'N/A'}',
@@ -163,6 +174,27 @@ class WindCard extends StatelessWidget {
                   const SizedBox(width: 4),
                   Text(
                     'Última observación: ${DateFormat('dd/MM/yyyy HH:mm').format(windData.fechaObservacion!)}',
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: Colors.grey[600],
+                    ),
+                  ),
+                ],
+              ),
+            ],
+
+            if (windData.latitud != null && windData.longitud != null) ...[
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Icon(
+                    Icons.public,
+                    size: 16,
+                    color: Colors.grey[600],
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    'Lat: ${windData.latitud!.toStringAsFixed(2)}  ·  Lon: ${windData.longitud!.toStringAsFixed(2)}',
                     style: TextStyle(
                       fontSize: 12,
                       color: Colors.grey[600],


### PR DESCRIPTION
## Summary
- adjust the wind data model to map the array-based IDEAM response safely
- update the weather service to use the IDEAM app token, parse list rows, and support department filtering
- refresh the weather screen UI with a department dropdown, richer empty/error states, and enhanced wind cards

## Testing
- not run (Flutter/Dart SDK is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7f5646910832d84d83f6a41bc26f8