### PR TITLE
Configure location permissions across platforms

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -4,4 +4,9 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-feature
+        android:name="android.hardware.location.gps"
+        android:required="false" />
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-feature
+        android:name="android.hardware.location.gps"
+        android:required="false" />
+
     <application
         android:label="pruebas"
         android:name="${applicationName}"

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -4,4 +4,9 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-feature
+        android:name="android.hardware.location.gps"
+        android:required="false" />
 </manifest>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -41,9 +41,11 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+        <key>CADisableMinimumFrameDurationOnPhone</key>
+        <true/>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
+        <true/>
+        <key>NSLocationWhenInUseUsageDescription</key>
+        <string>Necesitamos tu ubicación actual para mostrarte el clima local y actualizaciones en tiempo real.</string>
 </dict>
 </plist>

--- a/lib/screens/weather_screen.dart
+++ b/lib/screens/weather_screen.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:permission_handler/permission_handler.dart' as permission_handler;
 
@@ -105,6 +107,35 @@ class _WeatherScreenState extends State<WeatherScreen> {
       if (!mounted) return;
       setState(() {
         _errorMessage = error.message;
+        _isLoading = false;
+        _currentWeather = null;
+        _currentPosition = null;
+      });
+    } on PlatformException catch (error) {
+      if (!mounted) return;
+      setState(() {
+        final buffer = StringBuffer(
+          'No se pudo acceder a la ubicación del dispositivo en este momento.',
+        );
+
+        if (kIsWeb) {
+          buffer.write(
+            ' En la versión web, verifica que el navegador tenga permisos de ubicación activos o consulta manualmente tu ciudad desde el servicio meteorológico.',
+          );
+        } else if (!kIsWeb &&
+            (defaultTargetPlatform == TargetPlatform.macOS ||
+                defaultTargetPlatform == TargetPlatform.windows ||
+                defaultTargetPlatform == TargetPlatform.linux)) {
+          buffer.write(
+            ' En escritorio, asegúrate de habilitar el servicio de localización del sistema o consulta temporalmente el clima de tu ciudad de forma manual.',
+          );
+        }
+
+        if (error.message != null && error.message!.isNotEmpty) {
+          buffer.write(' Detalle técnico: ${error.message}.');
+        }
+
+        _errorMessage = buffer.toString();
         _isLoading = false;
         _currentWeather = null;
         _currentPosition = null;


### PR DESCRIPTION
## Summary
- add fine and coarse location permissions plus optional GPS feature flag to all Android manifests
- document iOS foreground location usage with a localized explanation for weather updates
- improve cross-platform messaging when location services are unavailable

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d80091020c832da833507ef7e5e94d