### PR TITLE
Fix permanent permission icon

### DIFF
--- a/lib/screens/weather_screen.dart
+++ b/lib/screens/weather_screen.dart
@@ -261,7 +261,7 @@ class _WeatherScreenState extends State<WeatherScreen> {
               )
             else if (_permissionDeniedForever)
               _buildStatusMessage(
-                icon: Icons.lock_location,
+                icon: Icons.lock_outline,
                 iconColor: Colors.deepOrange,
                 title: 'Permiso de ubicación denegado permanentemente',
                 message:


### PR DESCRIPTION
## Summary
- replace the deprecated `Icons.lock_location` with the valid `Icons.lock_outline` for the permanently denied permission state

## Testing
- flutter analyze *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d805318148832d965f53a504395728